### PR TITLE
Mass replace missing Notice characters

### DIFF
--- a/patch/RSCE_UTF8/13558_61.txt
+++ b/patch/RSCE_UTF8/13558_61.txt
@@ -163,7 +163,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -181,7 +181,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -307,7 +307,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13559_88.txt
+++ b/patch/RSCE_UTF8/13559_88.txt
@@ -117,7 +117,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>券</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -135,7 +135,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>券</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -261,7 +261,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>券のソーディアンデバイスが
+<TAG_007><TAG_013b><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13564_89.txt
+++ b/patch/RSCE_UTF8/13564_89.txt
@@ -49,7 +49,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80>
 [ENDBLOCK]
 <x18><x65><x58><xF8><x00><x80></color>を取得しました。
 

--- a/patch/RSCE_UTF8/13595_75.txt
+++ b/patch/RSCE_UTF8/13595_75.txt
@@ -542,7 +542,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>券</color>が
+<TAG_007><S03><turquoise><TAG_013d><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -560,7 +560,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>券</color>が
+<TAG_007><S03><turquoise><TAG_013d><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -686,7 +686,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>券のソーディアンデバイスが
+<TAG_007><TAG_013d><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13637_76.txt
+++ b/patch/RSCE_UTF8/13637_76.txt
@@ -1077,7 +1077,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1095,7 +1095,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1221,7 +1221,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>浮のソーディアンデバイスが
+<TAG_007><TAG_013c><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13643_26.txt
+++ b/patch/RSCE_UTF8/13643_26.txt
@@ -160,7 +160,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -178,7 +178,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -304,7 +304,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13658_85.txt
+++ b/patch/RSCE_UTF8/13658_85.txt
@@ -1386,7 +1386,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>券</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1404,7 +1404,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>券</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1530,7 +1530,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>券のソーディアンデバイスが
+<TAG_007><TAG_013c><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13673_72.txt
+++ b/patch/RSCE_UTF8/13673_72.txt
@@ -137,7 +137,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -155,7 +155,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -281,7 +281,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13675_82.txt
+++ b/patch/RSCE_UTF8/13675_82.txt
@@ -346,7 +346,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -364,7 +364,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -490,7 +490,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13678_42.txt
+++ b/patch/RSCE_UTF8/13678_42.txt
@@ -1648,7 +1648,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013e>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013e><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1666,7 +1666,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013e>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013e><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1792,7 +1792,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013e>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013e><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13682_71.txt
+++ b/patch/RSCE_UTF8/13682_71.txt
@@ -137,7 +137,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -155,7 +155,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -281,7 +281,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13684_68.txt
+++ b/patch/RSCE_UTF8/13684_68.txt
@@ -91,7 +91,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -109,7 +109,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -235,7 +235,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13721_77.txt
+++ b/patch/RSCE_UTF8/13721_77.txt
@@ -1454,7 +1454,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>@<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x40><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1472,7 +1472,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>@<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x40><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1598,7 +1598,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>@<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x40><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13724_65.txt
+++ b/patch/RSCE_UTF8/13724_65.txt
@@ -1105,7 +1105,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x3C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1123,7 +1123,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x3C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1249,7 +1249,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c><<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x3C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13743_64.txt
+++ b/patch/RSCE_UTF8/13743_64.txt
@@ -1115,7 +1115,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x3C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1133,7 +1133,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x3C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1259,7 +1259,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c><<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x3C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13745_77.txt
+++ b/patch/RSCE_UTF8/13745_77.txt
@@ -1217,7 +1217,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x48><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1235,7 +1235,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x48><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1361,7 +1361,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>H<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x48><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13762_25.txt
+++ b/patch/RSCE_UTF8/13762_25.txt
@@ -479,7 +479,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -497,7 +497,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -623,7 +623,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13766_13.txt
+++ b/patch/RSCE_UTF8/13766_13.txt
@@ -169,7 +169,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -187,7 +187,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -313,7 +313,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13768_27.txt
+++ b/patch/RSCE_UTF8/13768_27.txt
@@ -479,7 +479,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -497,7 +497,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -623,7 +623,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13772_13.txt
+++ b/patch/RSCE_UTF8/13772_13.txt
@@ -169,7 +169,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -187,7 +187,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -313,7 +313,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13819_56.txt
+++ b/patch/RSCE_UTF8/13819_56.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13820_58.txt
+++ b/patch/RSCE_UTF8/13820_58.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13821_116.txt
+++ b/patch/RSCE_UTF8/13821_116.txt
@@ -65,7 +65,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -83,7 +83,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -209,7 +209,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13822_55.txt
+++ b/patch/RSCE_UTF8/13822_55.txt
@@ -354,7 +354,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -372,7 +372,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -498,7 +498,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13823_39.txt
+++ b/patch/RSCE_UTF8/13823_39.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13824_75.txt
+++ b/patch/RSCE_UTF8/13824_75.txt
@@ -32,7 +32,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -50,7 +50,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -176,7 +176,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13825_85.txt
+++ b/patch/RSCE_UTF8/13825_85.txt
@@ -72,7 +72,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -90,7 +90,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -216,7 +216,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13826_51.txt
+++ b/patch/RSCE_UTF8/13826_51.txt
@@ -41,7 +41,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -59,7 +59,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -185,7 +185,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13827_73.txt
+++ b/patch/RSCE_UTF8/13827_73.txt
@@ -283,7 +283,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -301,7 +301,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -427,7 +427,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13828_73.txt
+++ b/patch/RSCE_UTF8/13828_73.txt
@@ -71,7 +71,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -89,7 +89,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -215,7 +215,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13829_87.txt
+++ b/patch/RSCE_UTF8/13829_87.txt
@@ -73,7 +73,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -91,7 +91,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -217,7 +217,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13830_97.txt
+++ b/patch/RSCE_UTF8/13830_97.txt
@@ -53,7 +53,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -71,7 +71,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -197,7 +197,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13832_123.txt
+++ b/patch/RSCE_UTF8/13832_123.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13833_123.txt
+++ b/patch/RSCE_UTF8/13833_123.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13834_123.txt
+++ b/patch/RSCE_UTF8/13834_123.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13835_123.txt
+++ b/patch/RSCE_UTF8/13835_123.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13836_123.txt
+++ b/patch/RSCE_UTF8/13836_123.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13837_123.txt
+++ b/patch/RSCE_UTF8/13837_123.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13840_62.txt
+++ b/patch/RSCE_UTF8/13840_62.txt
@@ -467,7 +467,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -485,7 +485,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -611,7 +611,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13841_56.txt
+++ b/patch/RSCE_UTF8/13841_56.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13842_58.txt
+++ b/patch/RSCE_UTF8/13842_58.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13843_106.txt
+++ b/patch/RSCE_UTF8/13843_106.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13845_39.txt
+++ b/patch/RSCE_UTF8/13845_39.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13846_74.txt
+++ b/patch/RSCE_UTF8/13846_74.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13847_75.txt
+++ b/patch/RSCE_UTF8/13847_75.txt
@@ -36,7 +36,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -54,7 +54,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -180,7 +180,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13848_51.txt
+++ b/patch/RSCE_UTF8/13848_51.txt
@@ -41,7 +41,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -59,7 +59,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -185,7 +185,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13849_62.txt
+++ b/patch/RSCE_UTF8/13849_62.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13850_63.txt
+++ b/patch/RSCE_UTF8/13850_63.txt
@@ -35,7 +35,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -53,7 +53,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -179,7 +179,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13851_77.txt
+++ b/patch/RSCE_UTF8/13851_77.txt
@@ -37,7 +37,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -55,7 +55,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -181,7 +181,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13852_87.txt
+++ b/patch/RSCE_UTF8/13852_87.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13853_54.txt
+++ b/patch/RSCE_UTF8/13853_54.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13854_54.txt
+++ b/patch/RSCE_UTF8/13854_54.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13855_54.txt
+++ b/patch/RSCE_UTF8/13855_54.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13856_54.txt
+++ b/patch/RSCE_UTF8/13856_54.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13857_54.txt
+++ b/patch/RSCE_UTF8/13857_54.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13858_54.txt
+++ b/patch/RSCE_UTF8/13858_54.txt
@@ -17,7 +17,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -35,7 +35,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -161,7 +161,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13863_39.txt
+++ b/patch/RSCE_UTF8/13863_39.txt
@@ -1182,7 +1182,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1200,7 +1200,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1326,7 +1326,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>煽のソーディアンデバイスが
+<TAG_007><TAG_013c><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13864_35.txt
+++ b/patch/RSCE_UTF8/13864_35.txt
@@ -1237,7 +1237,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1255,7 +1255,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1381,7 +1381,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>煽のソーディアンデバイスが
+<TAG_007><TAG_013c><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13872_31.txt
+++ b/patch/RSCE_UTF8/13872_31.txt
@@ -523,7 +523,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -541,7 +541,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -667,7 +667,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13874_32.txt
+++ b/patch/RSCE_UTF8/13874_32.txt
@@ -455,7 +455,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x64><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -473,7 +473,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x64><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -599,7 +599,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>d<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x64><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13875_34.txt
+++ b/patch/RSCE_UTF8/13875_34.txt
@@ -89,7 +89,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -107,7 +107,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -233,7 +233,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13891_109.txt
+++ b/patch/RSCE_UTF8/13891_109.txt
@@ -1251,7 +1251,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x64><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1269,7 +1269,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x64><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1395,7 +1395,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>d<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x64><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13908_18.txt
+++ b/patch/RSCE_UTF8/13908_18.txt
@@ -133,7 +133,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>T<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x54><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -151,7 +151,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>T<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x54><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -277,7 +277,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>T<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x54><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13926_76.txt
+++ b/patch/RSCE_UTF8/13926_76.txt
@@ -851,7 +851,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -869,7 +869,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -995,7 +995,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>浮のソーディアンデバイスが
+<TAG_007><TAG_013c><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13942_67.txt
+++ b/patch/RSCE_UTF8/13942_67.txt
@@ -944,7 +944,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x48><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -962,7 +962,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x48><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1088,7 +1088,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>H<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x48><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13950_54.txt
+++ b/patch/RSCE_UTF8/13950_54.txt
@@ -633,7 +633,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x28><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -651,7 +651,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x28><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -777,7 +777,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>(<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x28><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13952_44.txt
+++ b/patch/RSCE_UTF8/13952_44.txt
@@ -682,7 +682,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -700,7 +700,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -826,7 +826,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>煽のソーディアンデバイスが
+<TAG_007><TAG_013c><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13958_54.txt
+++ b/patch/RSCE_UTF8/13958_54.txt
@@ -664,7 +664,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x28><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -682,7 +682,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x28><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -808,7 +808,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>(<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x28><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13960_41.txt
+++ b/patch/RSCE_UTF8/13960_41.txt
@@ -682,7 +682,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -700,7 +700,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -826,7 +826,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>浮のソーディアンデバイスが
+<TAG_007><TAG_013c><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13967_113.txt
+++ b/patch/RSCE_UTF8/13967_113.txt
@@ -370,7 +370,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -388,7 +388,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -514,7 +514,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13969_61.txt
+++ b/patch/RSCE_UTF8/13969_61.txt
@@ -32,7 +32,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -50,7 +50,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -176,7 +176,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13975_115.txt
+++ b/patch/RSCE_UTF8/13975_115.txt
@@ -409,7 +409,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -427,7 +427,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -553,7 +553,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/13991_29.txt
+++ b/patch/RSCE_UTF8/13991_29.txt
@@ -654,7 +654,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -672,7 +672,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>浮</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -798,7 +798,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>浮のソーディアンデバイスが
+<TAG_007><TAG_013c><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14012_28.txt
+++ b/patch/RSCE_UTF8/14012_28.txt
@@ -648,7 +648,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x28><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -666,7 +666,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x28><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -792,7 +792,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>(<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x28><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14035_71.txt
+++ b/patch/RSCE_UTF8/14035_71.txt
@@ -250,7 +250,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x3C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -268,7 +268,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x3C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -394,7 +394,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b><<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x3C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14042_71.txt
+++ b/patch/RSCE_UTF8/14042_71.txt
@@ -250,7 +250,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -268,7 +268,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -394,7 +394,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14056_135.txt
+++ b/patch/RSCE_UTF8/14056_135.txt
@@ -61,7 +61,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013h>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013h><x48><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -79,7 +79,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013h>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013h><x48><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -205,7 +205,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013h>H<x80>のソーディアンデバイスが
+<TAG_007><TAG_013h><x48><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14064_69.txt
+++ b/patch/RSCE_UTF8/14064_69.txt
@@ -834,7 +834,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -852,7 +852,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -978,7 +978,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14066_29.txt
+++ b/patch/RSCE_UTF8/14066_29.txt
@@ -125,7 +125,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80>
 [ENDBLOCK]
 <x18><x65><x58><xF0><x00><x80></color>を取得しました。
 

--- a/patch/RSCE_UTF8/14072_65.txt
+++ b/patch/RSCE_UTF8/14072_65.txt
@@ -867,7 +867,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -885,7 +885,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1011,7 +1011,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14074_29.txt
+++ b/patch/RSCE_UTF8/14074_29.txt
@@ -125,7 +125,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80>
 [ENDBLOCK]
 <x18><x65><x58><xF0><x00><x80></color>を取得しました。
 

--- a/patch/RSCE_UTF8/14115_128.txt
+++ b/patch/RSCE_UTF8/14115_128.txt
@@ -1078,7 +1078,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x48><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1096,7 +1096,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x48><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1222,7 +1222,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>H<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x48><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14118_112.txt
+++ b/patch/RSCE_UTF8/14118_112.txt
@@ -1211,7 +1211,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1229,7 +1229,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1355,7 +1355,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14122_44.txt
+++ b/patch/RSCE_UTF8/14122_44.txt
@@ -464,7 +464,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -482,7 +482,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -608,7 +608,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14124_120.txt
+++ b/patch/RSCE_UTF8/14124_120.txt
@@ -957,7 +957,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -975,7 +975,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1101,7 +1101,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14131_49.txt
+++ b/patch/RSCE_UTF8/14131_49.txt
@@ -539,7 +539,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -557,7 +557,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -683,7 +683,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14137_52.txt
+++ b/patch/RSCE_UTF8/14137_52.txt
@@ -150,7 +150,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -168,7 +168,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -176,7 +176,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -294,7 +294,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14138_58.txt
+++ b/patch/RSCE_UTF8/14138_58.txt
@@ -159,7 +159,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x64><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -177,7 +177,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x64><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -303,7 +303,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>d<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x64><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14139_85.txt
+++ b/patch/RSCE_UTF8/14139_85.txt
@@ -196,7 +196,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -214,7 +214,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -340,7 +340,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14142_77.txt
+++ b/patch/RSCE_UTF8/14142_77.txt
@@ -402,7 +402,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>漢</color>が
+<TAG_007><S03><turquoise><TAG_013d><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -420,7 +420,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>漢</color>が
+<TAG_007><S03><turquoise><TAG_013d><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -546,7 +546,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>漢のソーディアンデバイスが
+<TAG_007><TAG_013d><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14143_69.txt
+++ b/patch/RSCE_UTF8/14143_69.txt
@@ -286,7 +286,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -304,7 +304,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -312,7 +312,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -430,7 +430,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14144_31.txt
+++ b/patch/RSCE_UTF8/14144_31.txt
@@ -217,7 +217,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x60><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -235,7 +235,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x60><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -361,7 +361,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>`<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x60><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14145_36.txt
+++ b/patch/RSCE_UTF8/14145_36.txt
@@ -229,7 +229,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -247,7 +247,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -255,7 +255,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -373,7 +373,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14146_27.txt
+++ b/patch/RSCE_UTF8/14146_27.txt
@@ -156,7 +156,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -174,7 +174,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -182,7 +182,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -300,7 +300,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14147_25.txt
+++ b/patch/RSCE_UTF8/14147_25.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14148_27.txt
+++ b/patch/RSCE_UTF8/14148_27.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14149_27.txt
+++ b/patch/RSCE_UTF8/14149_27.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14150_37.txt
+++ b/patch/RSCE_UTF8/14150_37.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14151_26.txt
+++ b/patch/RSCE_UTF8/14151_26.txt
@@ -129,7 +129,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -147,7 +147,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -155,7 +155,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -273,7 +273,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14152_26.txt
+++ b/patch/RSCE_UTF8/14152_26.txt
@@ -136,7 +136,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -154,7 +154,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -162,7 +162,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -280,7 +280,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14154_53.txt
+++ b/patch/RSCE_UTF8/14154_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14155_53.txt
+++ b/patch/RSCE_UTF8/14155_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14156_54.txt
+++ b/patch/RSCE_UTF8/14156_54.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14157_53.txt
+++ b/patch/RSCE_UTF8/14157_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14158_53.txt
+++ b/patch/RSCE_UTF8/14158_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14159_53.txt
+++ b/patch/RSCE_UTF8/14159_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14160_53.txt
+++ b/patch/RSCE_UTF8/14160_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14161_53.txt
+++ b/patch/RSCE_UTF8/14161_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14162_53.txt
+++ b/patch/RSCE_UTF8/14162_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14163_53.txt
+++ b/patch/RSCE_UTF8/14163_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14164_54.txt
+++ b/patch/RSCE_UTF8/14164_54.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14165_53.txt
+++ b/patch/RSCE_UTF8/14165_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14166_54.txt
+++ b/patch/RSCE_UTF8/14166_54.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14167_53.txt
+++ b/patch/RSCE_UTF8/14167_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14168_53.txt
+++ b/patch/RSCE_UTF8/14168_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14169_53.txt
+++ b/patch/RSCE_UTF8/14169_53.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14170_45.txt
+++ b/patch/RSCE_UTF8/14170_45.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14171_54.txt
+++ b/patch/RSCE_UTF8/14171_54.txt
@@ -126,7 +126,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -144,7 +144,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -152,7 +152,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -270,7 +270,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14176_65.txt
+++ b/patch/RSCE_UTF8/14176_65.txt
@@ -704,7 +704,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -722,7 +722,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -848,7 +848,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14178_54.txt
+++ b/patch/RSCE_UTF8/14178_54.txt
@@ -720,7 +720,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -738,7 +738,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -864,7 +864,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14180_41.txt
+++ b/patch/RSCE_UTF8/14180_41.txt
@@ -902,7 +902,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -920,7 +920,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1046,7 +1046,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14186_67.txt
+++ b/patch/RSCE_UTF8/14186_67.txt
@@ -700,7 +700,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -718,7 +718,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -844,7 +844,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14188_54.txt
+++ b/patch/RSCE_UTF8/14188_54.txt
@@ -716,7 +716,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -734,7 +734,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -860,7 +860,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14190_30.txt
+++ b/patch/RSCE_UTF8/14190_30.txt
@@ -616,7 +616,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -634,7 +634,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>$<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x24><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -760,7 +760,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>$<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x24><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14223_46.txt
+++ b/patch/RSCE_UTF8/14223_46.txt
@@ -710,7 +710,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -728,7 +728,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -854,7 +854,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14229_29.txt
+++ b/patch/RSCE_UTF8/14229_29.txt
@@ -425,7 +425,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -443,7 +443,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -569,7 +569,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14276_39.txt
+++ b/patch/RSCE_UTF8/14276_39.txt
@@ -739,7 +739,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -757,7 +757,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -883,7 +883,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14281_30.txt
+++ b/patch/RSCE_UTF8/14281_30.txt
@@ -548,7 +548,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x28><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -566,7 +566,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x28><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -692,7 +692,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>(<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x28><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14284_38.txt
+++ b/patch/RSCE_UTF8/14284_38.txt
@@ -739,7 +739,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -757,7 +757,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -883,7 +883,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14289_16.txt
+++ b/patch/RSCE_UTF8/14289_16.txt
@@ -302,7 +302,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -320,7 +320,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -446,7 +446,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14295_37.txt
+++ b/patch/RSCE_UTF8/14295_37.txt
@@ -497,7 +497,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80>
 [ENDBLOCK]
 <x18><x65><x58><xF0><x00><x80></color>を取得しました。
 

--- a/patch/RSCE_UTF8/14297_28.txt
+++ b/patch/RSCE_UTF8/14297_28.txt
@@ -681,7 +681,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -699,7 +699,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -825,7 +825,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>煽のソーディアンデバイスが
+<TAG_007><TAG_013c><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14301_15.txt
+++ b/patch/RSCE_UTF8/14301_15.txt
@@ -471,7 +471,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -489,7 +489,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -615,7 +615,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14309_40.txt
+++ b/patch/RSCE_UTF8/14309_40.txt
@@ -704,7 +704,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -722,7 +722,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>煽</color>が
+<TAG_007><S03><turquoise><TAG_013c><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -848,7 +848,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>煽のソーディアンデバイスが
+<TAG_007><TAG_013c><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14313_15.txt
+++ b/patch/RSCE_UTF8/14313_15.txt
@@ -471,7 +471,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -489,7 +489,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -615,7 +615,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14339_135.txt
+++ b/patch/RSCE_UTF8/14339_135.txt
@@ -1082,7 +1082,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>8<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x38><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1100,7 +1100,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>8<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x38><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1226,7 +1226,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>8<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x38><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14340_90.txt
+++ b/patch/RSCE_UTF8/14340_90.txt
@@ -46,7 +46,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80>
 [ENDBLOCK]
 <x18><x65><x58><xE8><x00><x80></color>を取得しました。
 

--- a/patch/RSCE_UTF8/14341_131.txt
+++ b/patch/RSCE_UTF8/14341_131.txt
@@ -78,7 +78,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80>
 [ENDBLOCK]
 <x18><x65><x58><xEC><x00><x80></color>を取得しました。
 

--- a/patch/RSCE_UTF8/14387_42.txt
+++ b/patch/RSCE_UTF8/14387_42.txt
@@ -911,7 +911,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x34><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -929,7 +929,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x34><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1055,7 +1055,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>4<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x34><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14388_57.txt
+++ b/patch/RSCE_UTF8/14388_57.txt
@@ -1101,7 +1101,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>p<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x70><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1119,7 +1119,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>p<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x70><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1245,7 +1245,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>p<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x70><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14390_65.txt
+++ b/patch/RSCE_UTF8/14390_65.txt
@@ -148,7 +148,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -166,7 +166,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -292,7 +292,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14395_42.txt
+++ b/patch/RSCE_UTF8/14395_42.txt
@@ -911,7 +911,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x34><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -929,7 +929,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x34><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1055,7 +1055,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>4<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x34><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14396_48.txt
+++ b/patch/RSCE_UTF8/14396_48.txt
@@ -851,7 +851,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x60><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -869,7 +869,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x60><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -995,7 +995,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>`<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x60><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14398_65.txt
+++ b/patch/RSCE_UTF8/14398_65.txt
@@ -148,7 +148,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -166,7 +166,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>煽</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -292,7 +292,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>煽のソーディアンデバイスが
+<TAG_007><TAG_013a><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14405_34.txt
+++ b/patch/RSCE_UTF8/14405_34.txt
@@ -459,7 +459,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -477,7 +477,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -603,7 +603,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>煽のソーディアンデバイスが
+<TAG_007><TAG_013b><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14407_58.txt
+++ b/patch/RSCE_UTF8/14407_58.txt
@@ -1175,7 +1175,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x50><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1193,7 +1193,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x50><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1319,7 +1319,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>P<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x50><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14414_38.txt
+++ b/patch/RSCE_UTF8/14414_38.txt
@@ -199,7 +199,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -217,7 +217,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -343,7 +343,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>煽のソーディアンデバイスが
+<TAG_007><TAG_013b><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14415_32.txt
+++ b/patch/RSCE_UTF8/14415_32.txt
@@ -93,7 +93,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -111,7 +111,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -237,7 +237,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14416_34.txt
+++ b/patch/RSCE_UTF8/14416_34.txt
@@ -456,7 +456,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -474,7 +474,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -600,7 +600,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>煽のソーディアンデバイスが
+<TAG_007><TAG_013b><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14418_54.txt
+++ b/patch/RSCE_UTF8/14418_54.txt
@@ -1093,7 +1093,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x50><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -1111,7 +1111,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x50><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1237,7 +1237,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>P<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x50><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14425_38.txt
+++ b/patch/RSCE_UTF8/14425_38.txt
@@ -195,7 +195,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -213,7 +213,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>煽</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE4><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -339,7 +339,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>煽のソーディアンデバイスが
+<TAG_007><TAG_013b><xE4><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14426_32.txt
+++ b/patch/RSCE_UTF8/14426_32.txt
@@ -93,7 +93,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -111,7 +111,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -237,7 +237,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14431_117.txt
+++ b/patch/RSCE_UTF8/14431_117.txt
@@ -47,7 +47,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x28><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -65,7 +65,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>(<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x28><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -191,7 +191,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>(<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x28><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14445_80.txt
+++ b/patch/RSCE_UTF8/14445_80.txt
@@ -6,7 +6,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>|<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x7C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -24,7 +24,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>|<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x7C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -150,7 +150,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>|<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x7C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14463_41.txt
+++ b/patch/RSCE_UTF8/14463_41.txt
@@ -548,7 +548,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -566,7 +566,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -692,7 +692,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14496_77.txt
+++ b/patch/RSCE_UTF8/14496_77.txt
@@ -120,7 +120,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -138,7 +138,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -264,7 +264,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14497_75.txt
+++ b/patch/RSCE_UTF8/14497_75.txt
@@ -48,7 +48,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -66,7 +66,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -192,7 +192,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14502_54.txt
+++ b/patch/RSCE_UTF8/14502_54.txt
@@ -6,7 +6,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -24,7 +24,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -150,7 +150,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14507_71.txt
+++ b/patch/RSCE_UTF8/14507_71.txt
@@ -97,7 +97,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x48><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -115,7 +115,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>H<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x48><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -241,7 +241,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>H<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x48><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14508_75.txt
+++ b/patch/RSCE_UTF8/14508_75.txt
@@ -282,7 +282,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013g>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013g><x50><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -300,7 +300,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013g>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013g><x50><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -426,7 +426,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013g>P<x80>のソーディアンデバイスが
+<TAG_007><TAG_013g><x50><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14509_21.txt
+++ b/patch/RSCE_UTF8/14509_21.txt
@@ -93,7 +93,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>l<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x6C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -111,7 +111,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>l<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x6C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -237,7 +237,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>l<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x6C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14510_21.txt
+++ b/patch/RSCE_UTF8/14510_21.txt
@@ -90,7 +90,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>t<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x74><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -108,7 +108,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>t<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x74><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -234,7 +234,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>t<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x74><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14511_20.txt
+++ b/patch/RSCE_UTF8/14511_20.txt
@@ -92,7 +92,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>t<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x74><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -110,7 +110,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>t<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x74><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -236,7 +236,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>t<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x74><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14512_75.txt
+++ b/patch/RSCE_UTF8/14512_75.txt
@@ -195,7 +195,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>X<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x78><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -213,7 +213,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>X<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x78><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -339,7 +339,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>X<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x78><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14513_50.txt
+++ b/patch/RSCE_UTF8/14513_50.txt
@@ -92,7 +92,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -110,7 +110,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -236,7 +236,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14515_50.txt
+++ b/patch/RSCE_UTF8/14515_50.txt
@@ -110,7 +110,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -128,7 +128,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -254,7 +254,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14517_50.txt
+++ b/patch/RSCE_UTF8/14517_50.txt
@@ -90,7 +90,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -108,7 +108,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -234,7 +234,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14518_50.txt
+++ b/patch/RSCE_UTF8/14518_50.txt
@@ -110,7 +110,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -128,7 +128,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -254,7 +254,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14519_50.txt
+++ b/patch/RSCE_UTF8/14519_50.txt
@@ -90,7 +90,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -108,7 +108,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -234,7 +234,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14521_50.txt
+++ b/patch/RSCE_UTF8/14521_50.txt
@@ -92,7 +92,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -110,7 +110,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>\<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x5C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -118,7 +118,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-称号：<turquoise><x1A><x2C><x00><x00><x05><x00>qH<x80><x98><x80>
+称号：<turquoise><x1A><x2C><x00><x00><x05><x00>q<x48><x80><x98><x80>
 [ENDBLOCK]
 <x18><x65><x58><x7C><x00><x80></color>を取得しました。
 
@@ -236,7 +236,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>\<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x5C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14522_50.txt
+++ b/patch/RSCE_UTF8/14522_50.txt
@@ -95,7 +95,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x3C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -113,7 +113,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c><<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x3C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -239,7 +239,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c><<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x3C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14523_50.txt
+++ b/patch/RSCE_UTF8/14523_50.txt
@@ -110,7 +110,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -128,7 +128,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -254,7 +254,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14524_50.txt
+++ b/patch/RSCE_UTF8/14524_50.txt
@@ -92,7 +92,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -110,7 +110,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>D<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x44><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -236,7 +236,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>D<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x44><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14534_76.txt
+++ b/patch/RSCE_UTF8/14534_76.txt
@@ -75,7 +75,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x34><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -93,7 +93,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x34><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -219,7 +219,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>4<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x34><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14568_109.txt
+++ b/patch/RSCE_UTF8/14568_109.txt
@@ -22,7 +22,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>8<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x38><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -40,7 +40,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013d>8<x80></color>が
+<TAG_007><S03><turquoise><TAG_013d><x38><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -166,7 +166,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013d>8<x80>のソーディアンデバイスが
+<TAG_007><TAG_013d><x38><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14610_52.txt
+++ b/patch/RSCE_UTF8/14610_52.txt
@@ -6,7 +6,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x30><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -24,7 +24,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>0<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x30><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -150,7 +150,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>0<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x30><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14611_58.txt
+++ b/patch/RSCE_UTF8/14611_58.txt
@@ -6,7 +6,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x50><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -24,7 +24,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>P<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x50><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -150,7 +150,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>P<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x50><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14613_115.txt
+++ b/patch/RSCE_UTF8/14613_115.txt
@@ -26,7 +26,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013e>漢</color>が
+<TAG_007><S03><turquoise><TAG_013e><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -44,7 +44,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013e>漢</color>が
+<TAG_007><S03><turquoise><TAG_013e><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -170,7 +170,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013e>漢のソーディアンデバイスが
+<TAG_007><TAG_013e><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14614_133.txt
+++ b/patch/RSCE_UTF8/14614_133.txt
@@ -11,7 +11,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013f>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013f><x60><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -29,7 +29,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013f>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013f><x60><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -155,7 +155,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013f>`<x80>のソーディアンデバイスが
+<TAG_007><TAG_013f><x60><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14641_89.txt
+++ b/patch/RSCE_UTF8/14641_89.txt
@@ -769,7 +769,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x34><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -787,7 +787,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013c>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013c><x34><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -913,7 +913,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013c>4<x80>のソーディアンデバイスが
+<TAG_007><TAG_013c><x34><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14657_61.txt
+++ b/patch/RSCE_UTF8/14657_61.txt
@@ -54,7 +54,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013g>@<x80></color>が
+<TAG_007><S03><turquoise><TAG_013g><x40><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -72,7 +72,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013g>@<x80></color>が
+<TAG_007><S03><turquoise><TAG_013g><x40><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -198,7 +198,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013g>@<x80>のソーディアンデバイスが
+<TAG_007><TAG_013g><x40><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14735_145.txt
+++ b/patch/RSCE_UTF8/14735_145.txt
@@ -379,7 +379,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -397,7 +397,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>浮</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE8><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -523,7 +523,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>浮のソーディアンデバイスが
+<TAG_007><TAG_013a><xE8><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14740_71.txt
+++ b/patch/RSCE_UTF8/14740_71.txt
@@ -23,7 +23,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -41,7 +41,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -167,7 +167,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14741_62.txt
+++ b/patch/RSCE_UTF8/14741_62.txt
@@ -23,7 +23,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -41,7 +41,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -167,7 +167,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14742_88.txt
+++ b/patch/RSCE_UTF8/14742_88.txt
@@ -23,7 +23,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -41,7 +41,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -167,7 +167,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14743_84.txt
+++ b/patch/RSCE_UTF8/14743_84.txt
@@ -23,7 +23,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -41,7 +41,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -167,7 +167,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14744_80.txt
+++ b/patch/RSCE_UTF8/14744_80.txt
@@ -23,7 +23,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -41,7 +41,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -167,7 +167,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14745_90.txt
+++ b/patch/RSCE_UTF8/14745_90.txt
@@ -23,7 +23,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -41,7 +41,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013a>券</color>が
+<TAG_007><S03><turquoise><TAG_013a><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -167,7 +167,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013a>券のソーディアンデバイスが
+<TAG_007><TAG_013a><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14749_99.txt
+++ b/patch/RSCE_UTF8/14749_99.txt
@@ -12,7 +12,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -30,7 +30,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>漢</color>が
+<TAG_007><S03><turquoise><TAG_013b><x9C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -156,7 +156,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>漢のソーディアンデバイスが
+<TAG_007><TAG_013b><x9C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14770_78.txt
+++ b/patch/RSCE_UTF8/14770_78.txt
@@ -56,7 +56,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>券</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE0><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -74,7 +74,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>券</color>が
+<TAG_007><S03><turquoise><TAG_013b><xE0><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -200,7 +200,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>券のソーディアンデバイスが
+<TAG_007><TAG_013b><xE0><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14802_64.txt
+++ b/patch/RSCE_UTF8/14802_64.txt
@@ -12,7 +12,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>|<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x7C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -30,7 +30,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>|<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x7C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -156,7 +156,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>|<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x7C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14803_64.txt
+++ b/patch/RSCE_UTF8/14803_64.txt
@@ -12,7 +12,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>|<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x7C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -30,7 +30,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013b>|<x80></color>が
+<TAG_007><S03><turquoise><TAG_013b><x7C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -156,7 +156,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013b>|<x80>のソーディアンデバイスが
+<TAG_007><TAG_013b><x7C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14812_88.txt
+++ b/patch/RSCE_UTF8/14812_88.txt
@@ -798,7 +798,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013g>t<x80></color>が
+<TAG_007><S03><turquoise><TAG_013g><x74><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -816,7 +816,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013g>t<x80></color>が
+<TAG_007><S03><turquoise><TAG_013g><x74><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -942,7 +942,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013g>t<x80>のソーディアンデバイスが
+<TAG_007><TAG_013g><x74><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14816_86.txt
+++ b/patch/RSCE_UTF8/14816_86.txt
@@ -893,7 +893,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013k>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013k><x60><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -911,7 +911,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013k>`<x80></color>が
+<TAG_007><S03><turquoise><TAG_013k><x60><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1037,7 +1037,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013k>`<x80>のソーディアンデバイスが
+<TAG_007><TAG_013k><x60><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14817_74.txt
+++ b/patch/RSCE_UTF8/14817_74.txt
@@ -960,7 +960,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013k>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013k><x34><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -978,7 +978,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013k>4<x80></color>が
+<TAG_007><S03><turquoise><TAG_013k><x34><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -1104,7 +1104,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013k>4<x80>のソーディアンデバイスが
+<TAG_007><TAG_013k><x34><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14819_147.txt
+++ b/patch/RSCE_UTF8/14819_147.txt
@@ -795,7 +795,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013k>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013k><x64><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -813,7 +813,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013k>d<x80></color>が
+<TAG_007><S03><turquoise><TAG_013k><x64><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -939,7 +939,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013k>d<x80>のソーディアンデバイスが
+<TAG_007><TAG_013k><x64><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice

--- a/patch/RSCE_UTF8/14843_45.txt
+++ b/patch/RSCE_UTF8/14843_45.txt
@@ -247,7 +247,7 @@ notice
 はい
 いいえ
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013e>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013e><x2C><x80></color>が
 [ENDBLOCK]
 パーティに加わりました。
 [ENDBLOCK]
@@ -265,7 +265,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><S03><turquoise><TAG_013e>,<x80></color>が
+<TAG_007><S03><turquoise><TAG_013e><x2C><x80></color>が
 [ENDBLOCK]
 パーティから抜けました。
 [ENDBLOCK]
@@ -391,7 +391,7 @@ notice
 [ENDBLOCK]
 notice
 [ENDBLOCK]
-<TAG_007><TAG_013e>,<x80>のソーディアンデバイスが
+<TAG_007><TAG_013e><x2C><x80>のソーディアンデバイスが
 使用可能になりました。
 [ENDBLOCK]
 notice


### PR DESCRIPTION
Mass replaced the missing chracter in the party notice that would freeze the game
```
煽 = <xE4><x80>
券 = <xE0><x80>
浮 = <xE8><x80>
@<x80> = <x40><x80>
漢 = <x9C><x80>
$<x80> = <x24><x80>
d<x80> = <x64><x80>
T<x80> = <x54><x80>
H<x80> = <x48><x80>
(<x80> = <x28><x80>
<<x80> = <x3C><x80>
0<x80> = <x30><x80>
,<x80> = <x2C><x80>
\<x80> = <x5C><x80>
`<x80> = <x60><x80>
8<x80> = <x38><x80>
4<x80> = <x34><x80>
p<x80> = <x70><x80>
l<x80> = <x6C><x80>
X<x80> = <x78><x80>
|<x80> = <x7C><x80>
P<x80> = <x50><x80>
D<x80> = <x44><x80>
t<x80> = <x74><x80>
```