### PR TITLE
Fix and rephrase minor things in the script

### DIFF
--- a/patch/RSCE_UTF8/13582_61.txt
+++ b/patch/RSCE_UTF8/13582_61.txt
@@ -20,7 +20,8 @@ Aw...<Lilith>.
 [ENDBLOCK]
 <Lilith>
 [ENDBLOCK]
-Don't you <Lilith> me, dummy! I can't
+//This line is accurate do not change it
+I'm not <Lilith>, dummy! I can't
 believe I have to be the one
 to wake you up.
 

--- a/patch/RSCE_UTF8/13582_61.txt
+++ b/patch/RSCE_UTF8/13582_61.txt
@@ -20,7 +20,7 @@ Aw...<Lilith>.
 [ENDBLOCK]
 <Lilith>
 [ENDBLOCK]
-I'm not <Lilith>, dummy! I can't
+Don't you <Lilith> me, dummy! I can't
 believe I have to be the one
 to wake you up.
 

--- a/patch/RSCE_UTF8/13870_44.txt
+++ b/patch/RSCE_UTF8/13870_44.txt
@@ -613,7 +613,7 @@ set it up so it would work.
 <Johnny>
 [ENDBLOCK]
 Well, that was supposed to
-be the stories' happy ending.
+be the story's happy ending.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/13988_63.txt
+++ b/patch/RSCE_UTF8/13988_63.txt
@@ -889,7 +889,7 @@ What's going on there?
 Kid
 [ENDBLOCK]
 How many times do we gotta
-tell you to get you to get it!?
+tell you before you get it!?
 [ENDBLOCK]
 Young Person
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14006_63.txt
+++ b/patch/RSCE_UTF8/14006_63.txt
@@ -889,7 +889,7 @@ What's going on there?
 Kid
 [ENDBLOCK]
 How many times do we gotta
-tell you to get you to get it!?
+tell you before you get it!?
 [ENDBLOCK]
 Young Person
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14010_65.txt
+++ b/patch/RSCE_UTF8/14010_65.txt
@@ -1042,7 +1042,7 @@ What's going on there?
 Kid
 [ENDBLOCK]
 How many times do we gotta
-tell you to get you to get it!?
+tell you before you get it!?
 [ENDBLOCK]
 Young Person
 [ENDBLOCK]


### PR DESCRIPTION
Noticed a few minor things while browsing the recent commits, so I thought I'd contribute.

1) **stories'** would only be correct if there were plural stories, but here there is only one story. Could also be written as "happy ending to the story", but the usage of the Saxon genitive is also grammatically correct and more succinct.

2) Replaced the repetition of "get you to" with a shorter expression which has the same effect.

3) Fixed a minor contextual error in Stahn's dream sequence at the start of the game. Rather than saying she's not Lilith (which makes no sense in context), she's impatient with Stahn who's mumbling her name and taking his sweet time waking up.

Hope this helps.
