### PR TITLE
detective stahn fixes

### DIFF
--- a/patch/RSCE_UTF8/13730_63.txt
+++ b/patch/RSCE_UTF8/13730_63.txt
@@ -86,7 +86,7 @@ Hmph!
 <Rutee>
 [ENDBLOCK]
 Anyway, what kinda reputation do 
-you have to a reaction like that?
+you have to get a reaction like that?
 [ENDBLOCK]
 <Lion>
 [ENDBLOCK]
@@ -128,7 +128,7 @@ hear you there...
 Rude Soldier
 [ENDBLOCK]
 Hehe, this is awesome. This time,
-I'll make you mine girl for sure!
+I'll make you my girl for sure!
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14115_128.txt
+++ b/patch/RSCE_UTF8/14115_128.txt
@@ -399,7 +399,7 @@ This is getting a little interesting.
 [ENDBLOCK]
 Let's go to Terazzi. Come on.
 [ENDBLOCK]
-Sister
+Young Girl
 [ENDBLOCK]
 It seems there's been an
 incident at that house.
@@ -410,31 +410,30 @@ incident at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Yeah, there's been a bit
-of an incident. One of my
-soldiers was attacked.
+There's been a bit of an incident.
+One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-And who did it?
+Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, they've been caught.
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-What's wrong with you?
-You don't look so good.
+What's wrong?
+You don't look happy.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-Mmm...?
+Hmm?
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-Don't tell me, <Fayte>. Did
-this girl attack a soldier!?
+<Fayte>, are you saying
+this girl attacked the soldier!?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
@@ -442,174 +441,172 @@ this girl attack a soldier!?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Sir <Fayte>!
-I'm not the killer!
+Lord <Fayte>!
+I'm not the one who did it!
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-<Johnny>, please believe me too.
+Lord <Johnny>, please believe me.
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Surely such a small child... I can't
-believe she attacked a soldier.
+I can't believe such a small child
+would have attacked a soldier.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-But then again...
+But...
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
 I can't believe it either.
-Such a girl...
+Such a small girl...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Dear <Johnny>, please help me!
+Lord <Johnny>, please
+help me!
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-I can't help you if you
-don't help me.
+It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>, wait. can you
-give us a moment?
+<Fayte>, can you wait a bit before
+you deal with her?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-All right. Forgive me, but I have
-to take this girl into custody.
+All right. But, I'll take her
+into custody for now.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Also, why don't you ask around
-in the Moreau territory?
+Why don't you ask around
+in Moreau for more info?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-There might still be people
-who know about the case.
+There might be some people
+who know about the attack.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The incident occurred yesterday 
-morning. A soldier was attacked 
-here in the Moreau territory.
+The incident took place at dawn. A
+soldier was attacked in Moreau.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-Actually, there have been a
-number of similar incidents
-in the past few days.
+Actually, there's been similar
+incidents in the past few days.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The soldier who was attacked
-had two scratches on him.
+The soldiers attacked were left
+with two scratches on their bodies.
 [ENDBLOCK]
-soldier
+Soldier
 [ENDBLOCK]
-Based on the testimony of the 
-attacked soldier and witnesses.
-We arrived at that girl.
+Based on the soldiers' testimony
+and witnesses, we concluded that
+the girl was the culprit.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+However, there was a witness who saw
+the girl at the time of the incident.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I think that's why Mr. <Fayte> 
+gave you all the time you needed.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+It's a long story, but would you like
+to hear a summary of the case?
 Yes
 No
 
 [ENDBLOCK]
-Child
+Boy
 [ENDBLOCK]
 Yeah, I heard about the death.
-But he was playing with the 
-cat at the time of the murder.
+But she was playing with her cat
+under the house at that time.
 [ENDBLOCK]
-Young man.
+Boy
 [ENDBLOCK]
-Whoever's wearing Shiden outfits
-here stands out. Besides, he's been
-talking to the cat in a big voice.
+The guy that's dressed in
+Shiden gear. I'm sure he'll stand
+out. Besides, he was talking 
+to the cat in a big voice.
 [ENDBLOCK]
-YOUNG MAN.
+Boy
 [ENDBLOCK]
-Can you really talk to a cat?
+Can he really talk to a cat?
 [ENDBLOCK]
-Fish Shop
+Fish Seller
 [ENDBLOCK]
-A girl, right? I was in here shopping
-at the time of the incident.
+It was a girl? Yeah, I was
+at the store at that time.
 [ENDBLOCK]
-Fish Shop
+Fish Seller
 [ENDBLOCK]
-I'd been wondering for a long time,
-and when I thought he had made up
-his mind and wrapped up the goods, 
-he said he wanted something else.
+He was looking for quite a while, and
+when I thought he made up his mind
+and started to wrap the product, he
+said he wanted something different.
 [ENDBLOCK]
-Fish Shop
+Fish Seller
 [ENDBLOCK]
-I remember it well because it 
-happened over and over again.
-[ENDBLOCK]
-Soldier
-[ENDBLOCK]
-The other day, I was at the fish 
-market in the harbor. I saw a girl 
-who was making a lot of noise.
+I remember it well, because I've done 
+it so many times.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-I was kind of curious. I came
+The other day, I saw a girl causing a
+scene in the fish shop at the harbor.
+[ENDBLOCK]
+Soldier
+[ENDBLOCK]
+I was kind of curious, so I came
 straight back to this inn.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-As soon as I returned, the girl who
-was just at the harbor came out of
-the house by the weapons shop.
+As soon as I got home, I opened the
+sliding door and there was the girl,
+who was supposed to be at the port.
+Came from near the weapons shop.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-There are no secret passageways
-in this city. There should be no 
-such thing as a secret passage. 
-It's a wonder, really.
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Did you find out who did it?
+Did you find the culprit?
 Yes
 No
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Now, please go inside and give
-<Fayte> a debriefing.
+Now please go inside
+and brief <Fayte> on
+the situation.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Okay... If you find the culprit.
-Please come back.
+I see... Well, when you do find
+the culprit, please come back.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-So, do you want to hear
+Would you like to hear
 about the case?
 Yes
 No

--- a/patch/RSCE_UTF8/14116_86.txt
+++ b/patch/RSCE_UTF8/14116_86.txt
@@ -95,7 +95,7 @@ Yeah, I know.
 What is it?	Do 
 they hate me?
 [ENDBLOCK]
-Sister
+Young Girl
 [ENDBLOCK]
 It seems there's been an
 incident at that house.
@@ -106,31 +106,30 @@ incident at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Yeah, there's been a bit
-of an incident. One of my
-soldiers was attacked.
+There's been a bit of an incident.
+One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-And who did it?
+Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, they've been caught.
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-What's wrong with you?
-You don't look so good.
+What's wrong?
+You don't look happy.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-Mmm...?
+Hmm?
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-Don't tell me, <Fayte>. Did
-this girl attack a soldier!?
+<Fayte>, are you saying
+this girl attacked the soldier!?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
@@ -138,94 +137,91 @@ this girl attack a soldier!?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Sir <Fayte>!
-I'm not the killer!
+Lord <Fayte>!
+I'm not the one who did it!
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-<Johnny>, please believe me too.
+Lord <Johnny>, please believe me.
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Surely such a small child... I can't
-believe she attacked a soldier.
+I can't believe such a small child
+would have attacked a soldier.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-But then again...
+But...
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
 I can't believe it either.
-Such a girl...
+Such a small girl...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Dear <Johnny>, please help me!
+Lord <Johnny>, please
+help me!
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-I can't help you if you
-don't help me.
+It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>, wait. can you
-give us a moment?
+<Fayte>, can you wait a bit before
+you deal with her?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-All right. Forgive me, but I have
-to take this girl into custody.
+All right. But, I'll take her
+into custody for now.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Also, why don't you ask around
-in the Moreau territory?
+Why don't you ask around
+in Moreau for more info?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-There might still be people
-who know about the case.
+There might be some people
+who know about the attack.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The incident occurred yesterday 
-morning. A soldier was attacked 
-here in the Moreau territory.
+The incident took place at dawn. A
+soldier was attacked in Moreau.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-Actually, there have been a
-number of similar incidents
-in the past few days.
+Actually, there's been similar
+incidents in the past few days.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The soldier who was attacked
-had two scratches on him.
+The soldiers attacked were left
+with two scratches on their bodies.
 [ENDBLOCK]
-soldier
+Soldier
 [ENDBLOCK]
-Based on the testimony of the 
-attacked soldier and witnesses.
-We arrived at that girl.
+Based on the soldiers' testimony
+and witnesses, we concluded that
+the girl was the culprit.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+However, there was a witness who saw
+the girl at the time of the incident.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I think that's why Mr. <Fayte> 
+gave you all the time you needed.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+It's a long story, but would you like
+to hear a summary of the case?
 Yes
 No
 
@@ -240,7 +236,7 @@ Boy
 [ENDBLOCK]
 The guy that's dressed in
 Shiden gear. I'm sure he'll stand
-out. Besides he was talking 
+out. Besides, he was talking 
 to the cat in a big voice.
 [ENDBLOCK]
 Boy
@@ -264,21 +260,32 @@ Fish Seller
 I remember it well, because I've done 
 it so many times.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+The other day, I saw a girl causing a
+scene in the fish shop at the harbor.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I was kind of curious, so I came
+straight back to this inn.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+As soon as I got home, I opened the
+sliding door and there was the girl,
+who was supposed to be at the port.
+Came from near the weapons shop.
+[ENDBLOCK]
+Soldier
+[ENDBLOCK]
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
+[ENDBLOCK]
+Soldier
+[ENDBLOCK]
+Did you find the culprit?
 Yes
 No
 [ENDBLOCK]
@@ -292,19 +299,6 @@ Soldier
 [ENDBLOCK]
 I see... Well, when you do find
 the culprit, please come back.
-[ENDBLOCK]
-Soldier
-[ENDBLOCK]
-As soon as I returned home, I opened
-the sliding door and found the boy who
-was supposed to be at the port coming
-out of the house by the weapons shop.
-[ENDBLOCK]
-Soldier
-[ENDBLOCK]
-There is no such thing as a secret
-passage in this city that no one 
-knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14118_112.txt
+++ b/patch/RSCE_UTF8/14118_112.txt
@@ -440,7 +440,7 @@ zzzzzzzzzzzzzzzzzzzzzz<x1D><x76><x40><x30><x80>
 ●●●●●●雲終了●●●●●●
 
 [ENDBLOCK]
-Sister
+Young Girl
 [ENDBLOCK]
 It seems there's been an
 incident at that house.
@@ -451,31 +451,30 @@ incident at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Yeah, there's been a bit
-of an incident. One of my
-soldiers was attacked.
+There's been a bit of an incident.
+One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-And who did it?
+Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, they've been caught.
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-What's wrong with you?
-You don't look so good.
+What's wrong?
+You don't look happy.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-Mmm...?
+Hmm?
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-Don't tell me, <Fayte>. Did
-this girl attack a soldier!?
+<Fayte>, are you saying
+this girl attacked the soldier!?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
@@ -483,94 +482,91 @@ this girl attack a soldier!?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Sir <Fayte>!
-I'm not the killer!
+Lord <Fayte>!
+I'm not the one who did it!
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-<Johnny>, please believe me too.
+Lord <Johnny>, please believe me.
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Surely such a small child... I can't
-believe she attacked a soldier.
+I can't believe such a small child
+would have attacked a soldier.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-But then again...
+But...
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
 I can't believe it either.
-Such a girl...
+Such a small girl...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Dear <Johnny>, please help me!
+Lord <Johnny>, please
+help me!
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-I can't help you if you
-don't help me.
+It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>, wait. can you
-give us a moment?
+<Fayte>, can you wait a bit before
+you deal with her?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-All right. Forgive me, but I have
-to take this girl into custody.
+All right. But, I'll take her
+into custody for now.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Also, why don't you ask around
-in the Moreau territory?
+Why don't you ask around
+in Moreau for more info?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-There might still be people
-who know about the case.
+There might be some people
+who know about the attack.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The incident occurred yesterday 
-morning. A soldier was attacked 
-here in the Moreau territory.
+The incident took place at dawn. A
+soldier was attacked in Moreau.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-Actually, there have been a
-number of similar incidents
-in the past few days.
+Actually, there's been similar
+incidents in the past few days.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The soldier who was attacked
-had two scratches on him.
+The soldiers attacked were left
+with two scratches on their bodies.
 [ENDBLOCK]
-soldier
+Soldier
 [ENDBLOCK]
-Based on the testimony of the 
-attacked soldier and witnesses.
-We arrived at that girl.
+Based on the soldiers' testimony
+and witnesses, we concluded that
+the girl was the culprit.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+However, there was a witness who saw
+the girl at the time of the incident.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I think that's why Mr. <Fayte> 
+gave you all the time you needed.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+It's a long story, but would you like
+to hear a summary of the case?
 Yes
 No
 
@@ -585,7 +581,7 @@ Boy
 [ENDBLOCK]
 The guy that's dressed in
 Shiden gear. I'm sure he'll stand
-out. Besides he was talking 
+out. Besides, he was talking 
 to the cat in a big voice.
 [ENDBLOCK]
 Boy
@@ -628,8 +624,9 @@ Came from near the weapons shop.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-No one know of a secret passage 
-in this city. It's a mystery.
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
@@ -867,7 +864,7 @@ Fruit Merchant
 [ENDBLOCK]
 I heard that the head of
 a huge company in Seinegald 
-as working on this painting.
+was working on this painting.
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -879,7 +876,7 @@ Fruit Merchant
 [ENDBLOCK]
 Isn't this what happens
 when you go soft on things
-like Oberon Corporation?
+like the Oberon Corporation?
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -907,7 +904,7 @@ Fruit Merchant
 [ENDBLOCK]
 I heard that the head of
 a huge company in Seinegald 
-as working on this painting.
+was working on this painting.
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -919,7 +916,7 @@ Fruit Merchant
 [ENDBLOCK]
 Isn't this what happens
 when you go soft on things
-like Oberon Corporation?
+like the Oberon Corporation?
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -1002,8 +999,8 @@ Keep up the good work!
 Girl
 [ENDBLOCK]
 Why are we fighting the
-Terazzi territory? We are
-both a part of Aquaveil.
+Terazzi territory? Aren't we
+both a part of Aquaveil?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
@@ -1012,9 +1009,8 @@ get along with everyone.
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Shadows cast from the sky
-during that strange voice. 
-I'm scared out of my mind.
+Strange broadcasts, shadows in the
+sky... I'm scared out of my mind...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
@@ -1024,7 +1020,7 @@ What's an Aeth'er war anyway?
 Girl
 [ENDBLOCK]
 We didn't lose yet, did we?
-Wow! we actually won!
+Wow! We actually won!
 [ENDBLOCK]
 Fish Seller
 [ENDBLOCK]
@@ -1187,7 +1183,7 @@ standing over there?
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Hmmm, he’s kinda
+Hmmm, he's kinda
 important looking.
 [ENDBLOCK]
 Soldier
@@ -1237,7 +1233,7 @@ What...?
 [ENDBLOCK]
 <Tiberius>
 [ENDBLOCK]
-I heard the story from <Greybum>,
+I heard the story from <Greybum>.
 You're <Lion> Magnus!
 [ENDBLOCK]
 <Tiberius>

--- a/patch/RSCE_UTF8/14120_28.txt
+++ b/patch/RSCE_UTF8/14120_28.txt
@@ -1,7 +1,7 @@
 Young Girl
 [ENDBLOCK]
-There's been an incident
-at that house.
+It seems there's been an
+incident at that house.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
@@ -9,6 +9,7 @@ at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
+There's been a bit of an incident.
 One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
@@ -17,7 +18,7 @@ Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, she's been caught...
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
@@ -71,7 +72,7 @@ It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>、can you wait a bit before
+<Fayte>, can you wait a bit before
 you deal with her?
 [ENDBLOCK]
 <Fayte>
@@ -123,7 +124,7 @@ gave you all the time you needed.
 Soldier
 [ENDBLOCK]
 It's a long story, but would you like
-to hear a sum<Mary> of the case?
+to hear a summary of the case?
 Yes
 No
 
@@ -138,7 +139,7 @@ Boy
 [ENDBLOCK]
 The guy that's dressed in
 Shiden gear. I'm sure he'll stand
-out. Besides he was talking 
+out. Besides, he was talking 
 to the cat in a big voice.
 [ENDBLOCK]
 Boy
@@ -181,8 +182,9 @@ Came from near the weapons shop.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-No one know of a secret passage 
-in this city. It's a mystery.
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14124_120.txt
+++ b/patch/RSCE_UTF8/14124_120.txt
@@ -399,7 +399,7 @@ This is getting a little interesting.
 [ENDBLOCK]
 Let's go to Terazzi. Come on.
 [ENDBLOCK]
-Sister
+Young Girl
 [ENDBLOCK]
 It seems there's been an
 incident at that house.
@@ -410,31 +410,30 @@ incident at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Yeah, there's been a bit
-of an incident. One of my
-soldiers was attacked.
+There's been a bit of an incident.
+One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-And who did it?
+Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, they've been caught.
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-What's wrong with you?
-You don't look so good.
+What's wrong?
+You don't look happy.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-Mmm...?
+Hmm?
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-Don't tell me, <Fayte>. Did
-this girl attack a soldier!?
+<Fayte>, are you saying
+this girl attacked the soldier!?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
@@ -442,174 +441,172 @@ this girl attack a soldier!?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Sir <Fayte>!
-I'm not the killer!
+Lord <Fayte>!
+I'm not the one who did it!
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-<Johnny>, please believe me too.
+Lord <Johnny>, please believe me.
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Surely such a small child... I can't
-believe she attacked a soldier.
+I can't believe such a small child
+would have attacked a soldier.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-But then again...
+But...
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
 I can't believe it either.
-Such a girl...
+Such a small girl...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Dear <Johnny>, please help me!
+Lord <Johnny>, please
+help me!
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-I can't help you if you
-don't help me.
+It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>, wait. can you
-give us a moment?
+<Fayte>, can you wait a bit before
+you deal with her?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-All right. Forgive me, but I have
-to take this girl into custody.
+All right. But, I'll take her
+into custody for now.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Also, why don't you ask around
-in the Moreau territory?
+Why don't you ask around
+in Moreau for more info?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-There might still be people
-who know about the case.
+There might be some people
+who know about the attack.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The incident occurred yesterday 
-morning. A soldier was attacked 
-here in the Moreau territory.
+The incident took place at dawn. A
+soldier was attacked in Moreau.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-Actually, there have been a
-number of similar incidents
-in the past few days.
+Actually, there's been similar
+incidents in the past few days.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The soldier who was attacked
-had two scratches on him.
+The soldiers attacked were left
+with two scratches on their bodies.
 [ENDBLOCK]
-soldier
+Soldier
 [ENDBLOCK]
-Based on the testimony of the 
-attacked soldier and witnesses.
-We arrived at that girl.
+Based on the soldiers' testimony
+and witnesses, we concluded that
+the girl was the culprit.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+However, there was a witness who saw
+the girl at the time of the incident.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I think that's why Mr. <Fayte> 
+gave you all the time you needed.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+It's a long story, but would you like
+to hear a summary of the case?
 Yes
 No
 
 [ENDBLOCK]
-Child
+Boy
 [ENDBLOCK]
 Yeah, I heard about the death.
-But he was playing with the 
-cat at the time of the murder.
+But she was playing with her cat
+under the house at that time.
 [ENDBLOCK]
-Young man.
+Boy
 [ENDBLOCK]
-Whoever's wearing Shiden outfits
-here stands out. Besides, he's been
-talking to the cat in a big voice.
+The guy that's dressed in
+Shiden gear. I'm sure he'll stand
+out. Besides, he was talking 
+to the cat in a big voice.
 [ENDBLOCK]
-YOUNG MAN.
+Boy
 [ENDBLOCK]
-Can you really talk to a cat?
+Can he really talk to a cat?
 [ENDBLOCK]
-Fish Shop
+Fish Seller
 [ENDBLOCK]
-A girl, right? I was in here shopping
-at the time of the incident.
+It was a girl? Yeah, I was
+at the store at that time.
 [ENDBLOCK]
-Fish Shop
+Fish Seller
 [ENDBLOCK]
-I'd been wondering for a long time,
-and when I thought he had made up
-his mind and wrapped up the goods, 
-he said he wanted something else.
+He was looking for quite a while, and
+when I thought he made up his mind
+and started to wrap the product, he
+said he wanted something different.
 [ENDBLOCK]
-Fish Shop
+Fish Seller
 [ENDBLOCK]
-I remember it well because it 
-happened over and over again.
-[ENDBLOCK]
-Soldier
-[ENDBLOCK]
-The other day, I was at the fish 
-market in the harbor. I saw a girl 
-who was making a lot of noise.
+I remember it well, because I've done 
+it so many times.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-I was kind of curious. I came
+The other day, I saw a girl causing a
+scene in the fish shop at the harbor.
+[ENDBLOCK]
+Soldier
+[ENDBLOCK]
+I was kind of curious, so I came
 straight back to this inn.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-As soon as I returned, the girl who
-was just at the harbor came out of
-the house by the weapons shop.
+As soon as I got home, I opened the
+sliding door and there was the girl,
+who was supposed to be at the port.
+Came from near the weapons shop.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-There are no secret passageways
-in this city. There should be no 
-such thing as a secret passage. 
-It's a wonder, really.
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Did you find out who did it?
+Did you find the culprit?
 Yes
 No
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Now, please go inside and give
-<Fayte> a debriefing.
+Now please go inside
+and brief <Fayte> on
+the situation.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Okay... If you find the culprit.
-Please come back.
+I see... Well, when you do find
+the culprit, please come back.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-So, do you want to hear
+Would you like to hear
 about the case?
 Yes
 No

--- a/patch/RSCE_UTF8/14125_73.txt
+++ b/patch/RSCE_UTF8/14125_73.txt
@@ -95,7 +95,7 @@ Yeah, I know.
 What is it?	Do 
 they hate me?
 [ENDBLOCK]
-Sister
+Young Girl
 [ENDBLOCK]
 It seems there's been an
 incident at that house.
@@ -106,31 +106,30 @@ incident at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Yeah, there's been a bit
-of an incident. One of my
-soldiers was attacked.
+There's been a bit of an incident.
+One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-And who did it?
+Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, they've been caught.
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-What's wrong with you?
-You don't look so good.
+What's wrong?
+You don't look happy.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-Mmm...?
+Hmm?
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-Don't tell me, <Fayte>. Did
-this girl attack a soldier!?
+<Fayte>, are you saying
+this girl attacked the soldier!?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
@@ -138,94 +137,91 @@ this girl attack a soldier!?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Sir <Fayte>!
-I'm not the killer!
+Lord <Fayte>!
+I'm not the one who did it!
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-<Johnny>, please believe me too.
+Lord <Johnny>, please believe me.
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Surely such a small child... I can't
-believe she attacked a soldier.
+I can't believe such a small child
+would have attacked a soldier.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-But then again...
+But...
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
 I can't believe it either.
-Such a girl...
+Such a small girl...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Dear <Johnny>, please help me!
+Lord <Johnny>, please
+help me!
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-I can't help you if you
-don't help me.
+It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>, wait. can you
-give us a moment?
+<Fayte>, can you wait a bit before
+you deal with her?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-All right. Forgive me, but I have
-to take this girl into custody.
+All right. But, I'll take her
+into custody for now.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Also, why don't you ask around
-in the Moreau territory?
+Why don't you ask around
+in Moreau for more info?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-There might still be people
-who know about the case.
+There might be some people
+who know about the attack.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The incident occurred yesterday 
-morning. A soldier was attacked 
-here in the Moreau territory.
+The incident took place at dawn. A
+soldier was attacked in Moreau.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-Actually, there have been a
-number of similar incidents
-in the past few days.
+Actually, there's been similar
+incidents in the past few days.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The soldier who was attacked
-had two scratches on him.
+The soldiers attacked were left
+with two scratches on their bodies.
 [ENDBLOCK]
-soldier
+Soldier
 [ENDBLOCK]
-Based on the testimony of the 
-attacked soldier and witnesses.
-We arrived at that girl.
+Based on the soldiers' testimony
+and witnesses, we concluded that
+the girl was the culprit.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+However, there was a witness who saw
+the girl at the time of the incident.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I think that's why Mr. <Fayte> 
+gave you all the time you needed.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+It's a long story, but would you like
+to hear a summary of the case?
 Yes
 No
 
@@ -240,7 +236,7 @@ Boy
 [ENDBLOCK]
 The guy that's dressed in
 Shiden gear. I'm sure he'll stand
-out. Besides he was talking 
+out. Besides, he was talking 
 to the cat in a big voice.
 [ENDBLOCK]
 Boy
@@ -264,21 +260,32 @@ Fish Seller
 I remember it well, because I've done 
 it so many times.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+The other day, I saw a girl causing a
+scene in the fish shop at the harbor.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I was kind of curious, so I came
+straight back to this inn.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+As soon as I got home, I opened the
+sliding door and there was the girl,
+who was supposed to be at the port.
+Came from near the weapons shop.
+[ENDBLOCK]
+Soldier
+[ENDBLOCK]
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
+[ENDBLOCK]
+Soldier
+[ENDBLOCK]
+Did you find the culprit?
 Yes
 No
 [ENDBLOCK]
@@ -292,19 +299,6 @@ Soldier
 [ENDBLOCK]
 I see... Well, when you do find
 the culprit, please come back.
-[ENDBLOCK]
-Soldier
-[ENDBLOCK]
-As soon as I returned home, I opened
-the sliding door and found the boy who
-was supposed to be at the port coming
-out of the house by the weapons shop.
-[ENDBLOCK]
-Soldier
-[ENDBLOCK]
-There is no such thing as a secret
-passage in this city that no one 
-knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14127_106.txt
+++ b/patch/RSCE_UTF8/14127_106.txt
@@ -87,7 +87,7 @@ zzzzzzzzzzzzzzzzzzzzzz<x1D><x76><x40><x30><x80>
 ●●●●●●雲終了●●●●●●
 
 [ENDBLOCK]
-Sister
+Young Girl
 [ENDBLOCK]
 It seems there's been an
 incident at that house.
@@ -98,31 +98,30 @@ incident at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Yeah, there's been a bit
-of an incident. One of my
-soldiers was attacked.
+There's been a bit of an incident.
+One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-And who did it?
+Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, they've been caught.
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-What's wrong with you?
-You don't look so good.
+What's wrong?
+You don't look happy.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-Mmm...?
+Hmm?
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
-Don't tell me, <Fayte>. Did
-this girl attack a soldier!?
+<Fayte>, are you saying
+this girl attacked the soldier!?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
@@ -130,94 +129,91 @@ this girl attack a soldier!?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Sir <Fayte>!
-I'm not the killer!
+Lord <Fayte>!
+I'm not the one who did it!
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-<Johnny>, please believe me too.
+Lord <Johnny>, please believe me.
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
-Surely such a small child... I can't
-believe she attacked a soldier.
+I can't believe such a small child
+would have attacked a soldier.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-But then again...
+But...
 [ENDBLOCK]
 <Stahn>
 [ENDBLOCK]
 I can't believe it either.
-Such a girl...
+Such a small girl...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Dear <Johnny>, please help me!
+Lord <Johnny>, please
+help me!
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-I can't help you if you
-don't help me.
+It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>, wait. can you
-give us a moment?
+<Fayte>, can you wait a bit before
+you deal with her?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-All right. Forgive me, but I have
-to take this girl into custody.
+All right. But, I'll take her
+into custody for now.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Also, why don't you ask around
-in the Moreau territory?
+Why don't you ask around
+in Moreau for more info?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-There might still be people
-who know about the case.
+There might be some people
+who know about the attack.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The incident occurred yesterday 
-morning. A soldier was attacked 
-here in the Moreau territory.
+The incident took place at dawn. A
+soldier was attacked in Moreau.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-Actually, there have been a
-number of similar incidents
-in the past few days.
+Actually, there's been similar
+incidents in the past few days.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-The soldier who was attacked
-had two scratches on him.
+The soldiers attacked were left
+with two scratches on their bodies.
 [ENDBLOCK]
-soldier
+Soldier
 [ENDBLOCK]
-Based on the testimony of the 
-attacked soldier and witnesses.
-We arrived at that girl.
+Based on the soldiers' testimony
+and witnesses, we concluded that
+the girl was the culprit.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-However, I have an
-alibi that I saw the girl at
-the time of the incident.
+However, there was a witness who saw
+the girl at the time of the incident.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-I think that's why Master <Fayte> 
-gave you all this time.
+I think that's why Mr. <Fayte> 
+gave you all the time you needed.
 [ENDBLOCK]
-Soldier.
+Soldier
 [ENDBLOCK]
-It's a long story. Would 
-you like to hear a synopsis?
+It's a long story, but would you like
+to hear a summary of the case?
 Yes
 No
  
@@ -232,7 +228,7 @@ Boy
 [ENDBLOCK]
 The guy that's dressed in
 Shiden gear. I'm sure he'll stand
-out. Besides he was talking 
+out. Besides, he was talking 
 to the cat in a big voice.
 [ENDBLOCK]
 Boy
@@ -275,8 +271,9 @@ Came from near the weapons shop.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-No one know of a secret passage 
-in this city. It's a mystery.
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
@@ -286,7 +283,7 @@ No
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-Now please go inside 
+Now please go inside
 and brief <Fayte> on
 the situation.
 [ENDBLOCK]
@@ -514,7 +511,7 @@ Fruit Merchant
 [ENDBLOCK]
 I heard that the head of
 a huge company in Seinegald 
-as working on this painting.
+was working on this painting.
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -526,7 +523,7 @@ Fruit Merchant
 [ENDBLOCK]
 Isn't this what happens
 when you go soft on things
-like Oberon Corporation?
+like the Oberon Corporation?
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -554,7 +551,7 @@ Fruit Merchant
 [ENDBLOCK]
 I heard that the head of
 a huge company in Seinegald 
-as working on this painting.
+was working on this painting.
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -566,7 +563,7 @@ Fruit Merchant
 [ENDBLOCK]
 Isn't this what happens
 when you go soft on things
-like Oberon Corporation?
+like the Oberon Corporation?
 [ENDBLOCK]
 Fruit Merchant
 [ENDBLOCK]
@@ -649,8 +646,8 @@ Keep up the good work!
 Girl
 [ENDBLOCK]
 Why are we fighting the
-Terazzi territory? We are
-both a part of Aquaveil.
+Terazzi territory? Aren't we
+both a part of Aquaveil?
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
@@ -659,9 +656,8 @@ get along with everyone.
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
-Shadows cast from the sky
-during that strange voice. 
-I'm scared out of my mind.
+Strange broadcasts, shadows in the
+sky... I'm scared out of my mind...
 [ENDBLOCK]
 Girl
 [ENDBLOCK]
@@ -671,7 +667,7 @@ What's an Aeth'er war anyway?
 Girl
 [ENDBLOCK]
 We didn't lose yet, did we?
-Wow! we actually won!
+Wow! We actually won!
 [ENDBLOCK]
 Fish Seller
 [ENDBLOCK]

--- a/patch/RSCE_UTF8/14129_28.txt
+++ b/patch/RSCE_UTF8/14129_28.txt
@@ -2,8 +2,8 @@ Young Girl
 [ENDBLOCK]
 <IGNORE>
 [ENDBLOCK]
-There's been an incident
-at that house.
+It seems there's been an
+incident at that house.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
@@ -11,6 +11,7 @@ at that house.
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
+There's been a bit of an incident.
 One of my soldiers was attacked.
 [ENDBLOCK]
 <Stahn>
@@ -19,7 +20,7 @@ Who did it?
 [ENDBLOCK]
 <Fayte>
 [ENDBLOCK]
-Well, she's been caught...
+Well, they've been caught...
 [ENDBLOCK]
 <Rutee>
 [ENDBLOCK]
@@ -73,7 +74,7 @@ It seems I'll have to get involved.
 [ENDBLOCK]
 <Johnny>
 [ENDBLOCK]
-<Fayte>、can you wait a bit before
+<Fayte>, can you wait a bit before
 you deal with her?
 [ENDBLOCK]
 <Fayte>
@@ -125,7 +126,7 @@ gave you all the time you needed.
 Soldier
 [ENDBLOCK]
 It's a long story, but would you like
-to hear a sum<Mary> of the case?
+to hear a summary of the case?
 Yes
 No
 
@@ -140,7 +141,7 @@ Boy
 [ENDBLOCK]
 The guy that's dressed in
 Shiden gear. I'm sure he'll stand
-out. Besides he was talking 
+out. Besides, he was talking 
 to the cat in a big voice.
 [ENDBLOCK]
 Boy
@@ -183,8 +184,9 @@ Came from near the weapons shop.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]
-No one know of a secret passage 
-in this city. It's a mystery.
+There is no such thing as a secret
+passage in this city that no one 
+knows about. It's a mystery.
 [ENDBLOCK]
 Soldier
 [ENDBLOCK]


### PR DESCRIPTION
Made all files that include a certain part of the detective stahn event have consistent text (there were like 4 different writings)

Something to note: there were two files in particular (14125 and 14116) that had weird ordering and seemed to have repeated/erroneous dialogue in the interviewing citizens part.
I replaced it with the version of the dialogue from the other files and it fits with the original japanese order, so it seems the previous version was just wrong.
But just in case, that might be where errors with that scene would be if any turn up.